### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Fluentd output plugin for Vertica
+[Fluentd](http://fluentd.org) output plugin for Vertica
 =================================
 
 Simple batched output plugin for getting events into vertica.


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
